### PR TITLE
修复计算技能评价最大化功能

### DIFF
--- a/UmamusumeResponseAnalyzer/Database.cs
+++ b/UmamusumeResponseAnalyzer/Database.cs
@@ -217,7 +217,7 @@ namespace UmamusumeResponseAnalyzer
             get => idMap.ContainsKey(Id) ? idMap[Id] : null!;
             set => idMap[Id] = value;
         }
-        public (int GroupId, int Rarity, int Rate) Deconstruction(int Id) => (this[Id].GroupId, this[Id].Rarity, this[Id].Rate);
+        public (int GroupId, int Rarity, int Rate) Deconstruction(int Id) => this[Id].Deconstruction();
         public SkillData[] GetAllByGroupId(int groupId) => idMap.Where(x => x.Value.GroupId == groupId).Select(x => x.Value).ToArray();
 
         public class SkillData
@@ -256,8 +256,12 @@ namespace UmamusumeResponseAnalyzer
             public DistanceType Distance;
             public StyleType Style;
 
-            public SkillData Apply(Gallop.SingleModeChara chara_info, int level)
+            public SkillData Apply(Gallop.SingleModeChara chara_info, int level = int.MinValue)
             {
+                if (level == int.MinValue)
+                {
+                    level = chara_info.skill_tips_array.FirstOrDefault(x => x.group_id == GroupId && x.rarity == Rarity)?.level ?? 0;
+                }
                 var instance = Clone();
                 instance.ApplyHint(chara_info, level);
                 instance.ApplyProper(chara_info);
@@ -329,6 +333,7 @@ namespace UmamusumeResponseAnalyzer
                 };
 
             }
+            public (int GroupId, int Rarity, int Rate) Deconstruction() => (GroupId, Rarity, Rate);
             public SkillData Clone()
                 => new()
                 {

--- a/UmamusumeResponseAnalyzer/Handler/ParseSkillTipsResponse.cs
+++ b/UmamusumeResponseAnalyzer/Handler/ParseSkillTipsResponse.cs
@@ -36,7 +36,7 @@ namespace UmamusumeResponseAnalyzer.Handler
                     }
                 }
             }
-            
+
             // 保证技能列表中的列表都是最上位技能（有下位技能则去除），避免引入判断是否获取了上位技能的数组
             // 不知道dp时通过Skill.Inferior/Superior读到的技能cost是否apply了hint，姑且认为是apply了
             // 理想中tips里边应该是只保留最上位技能，下位技能去除
@@ -78,7 +78,7 @@ namespace UmamusumeResponseAnalyzer.Handler
                 }
                 AnsiConsole.WriteLine(info);    //debug
             }
-            
+
             // 01背包变种
             var dp = new int[totalSP + 1];
             var dpLog = new List<int>[totalSP + 1]; // 记录dp时所选的技能，存技能Id
@@ -143,19 +143,19 @@ namespace UmamusumeResponseAnalyzer.Handler
                     else if (IsBestOption(1))
                     {
                         dp[j] = choice[1];
-                        dpStatusSucceed(j - s.Cost);
+                        dpLog[j] = new List<int>(dpLog[j - s.Cost].ToArray());
                         dpLog[j].Add(s.Id);
                     }
                     else if (IsBestOption(2))
                     {
                         dp[j] = choice[2];
-                        dpStatusSucceed(j - SuperiorCost[0]);
+                        dpLog[j] = new List<int>(dpLog[j - SuperiorCost[0]].ToArray());
                         dpLog[j].Add(s.Superior.Id);
                     }
                     else if (IsBestOption(3))
                     {
                         dp[j] = choice[3];
-                        dpStatusSucceed(j - SuperiorCost[1]);
+                        dpLog[j] = new List<int>(dpLog[j - SuperiorCost[1]].ToArray());
                         dpLog[j].Add(s.Superior.Superior.Id);
                     }
 
@@ -166,13 +166,6 @@ namespace UmamusumeResponseAnalyzer.Handler
                             IsBest = choice[index] >= choice[k] && IsBest;
                         return IsBest;
                     };
-
-                    void dpStatusSucceed(int index)
-                    {
-                        dpLog[j] = new List<int>();
-                        for (int k = 0; k < dpLog[index].Count; k++)
-                            dpLog[j].Add(dpLog[index][k]);
-                    }
                 }
             }
 

--- a/UmamusumeResponseAnalyzer/Program.cs
+++ b/UmamusumeResponseAnalyzer/Program.cs
@@ -14,6 +14,13 @@ namespace UmamusumeResponseAnalyzer
     {
         public static async Task Main(string[] args)
         {
+#if DEBUG
+            Database.Initialize();
+            var bytes = File.ReadAllBytes(@"C:\Users\micro\AppData\Local\UmamusumeResponseAnalyzer\packets\22-05-13 01-18-51R.msgpack");
+            var jo = JsonConvert.DeserializeObject<Gallop.SingleModeCheckEventResponse>(MessagePack.MessagePackSerializer.ConvertToJson(bytes));
+            Handler.Handlers.ParseSkillTipsResponse(jo);
+            return;
+#endif
             Console.Title = $"UmamusumeResponseAnalyzer v{System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}";
             Console.OutputEncoding = Encoding.UTF8;
             //加载设置


### PR DESCRIPTION
尚未测试如果游戏中途已经点过技能是否会影响计算结果   
例如在育成中点了金技能的下位技能，如果是这种情况的话，最后在计算前应该要单独整一个临时技能在tips中换掉这个金技能，把金技能退化成一个无前继后继技能（防止TotalCost算下位）的普通技能，这个临时技能的Grade也要减掉原有下位的。处理金绿技能也大同小异，退化成一个普通金技能。  
因为不是很清楚怎么读取处理已经点过了的技能，所以这部分就没写，除此之外测试了几个数据都没问题。