### PR TITLE
Removed extra UmamusumeResponseAnalyzer from download URL from github url

### DIFF
--- a/UmamusumeResponseAnalyzer/Program.cs
+++ b/UmamusumeResponseAnalyzer/Program.cs
@@ -308,7 +308,7 @@ namespace UmamusumeResponseAnalyzer
         }
         static string GetDownloadUrl(string filepath)
         {
-            const string CNHost = "https://assets.shuise.net";
+            const string CNHost = "https://assets.shuise.net/UmamusumeResponseAnalyzer";
             const string GithubHost = "https://raw.githubusercontent.com/EtherealAO/UmamusumeResponseAnalyzer/master";
             var isCN = RegionInfo.CurrentRegion.Name == "CN" || CultureInfo.CurrentUICulture.Name == "zh-CN";
             var ext = Path.GetExtension(filepath);
@@ -317,9 +317,9 @@ namespace UmamusumeResponseAnalyzer
             var host = isCN ? CNHost : GithubHost;
             return ext switch
             {
-                ".json" => $"{host}/UmamusumeResponseAnalyzer/{filename}",
-                ".exe" => isCN ? $"{host}/UmamusumeResponseAnalyzer/{filename}" : $"https://github.com/EtherealAO/UmamusumeResponseAnalyzer/releases/latest/download/UmamusumeResponseAnalyzer.exe"
-            };
+                ".json" => $"{host}/{filename}",
+                ".exe" => isCN ? $"{host}/{filename}" : $"https://github.com/EtherealAO/UmamusumeResponseAnalyzer/releases/latest/download/UmamusumeResponseAnalyzer.exe"
+				};
         }
         static async Task DownloadAssets(ProgressContext ctx, string instruction, string path)
         {


### PR DESCRIPTION
The GitHub URL is broken due to additional UmamusumeResponseAnalyzer in URL path (used for CN version)
Moved that addition to CNHost so both should work.

DeepL : 由于URL路径中增加了UmamusumeResponseAnalyzer（用于CN版本），GitHub的URL出现了问题。
把这个附加的东西移到了CNHost，所以两者都应该能用。
